### PR TITLE
feat: 画像を子供顔に変換する機能を追加

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,9 +9,11 @@ import ChatScreen from './components/ChatScreen';
 const App: React.FC = () => {
   const [appState, setAppState] = useState<AppState>({ screen: Screen.UPLOAD });
   const [childhoodPhoto, setChildhoodPhoto] = useState<string | null>(null);
+  const [convertedPhoto, setConvertedPhoto] = useState<string | null>(null);
 
   const handlePhotoUpload = useCallback((photoDataUrl: string) => {
     setChildhoodPhoto(photoDataUrl);
+    setConvertedPhoto(null);
     setAppState({ screen: Screen.CONNECTING });
   }, []);
 
@@ -19,8 +21,13 @@ const App: React.FC = () => {
     setAppState({ screen: Screen.CHAT });
   }, []);
 
+  const handleConverted = useCallback((transformed: string) => {
+    setConvertedPhoto(transformed);
+  }, []);
+
   const handleEndCall = useCallback(() => {
     setChildhoodPhoto(null);
+    setConvertedPhoto(null);
     setAppState({ screen: Screen.UPLOAD });
   }, []);
 
@@ -29,14 +36,14 @@ const App: React.FC = () => {
       case Screen.UPLOAD:
         return <UploadScreen onPhotoUpload={handlePhotoUpload} />;
       case Screen.CONNECTING:
-        return <ConnectingScreen onConnected={handleConnected} photo={childhoodPhoto} />;
+        return <ConnectingScreen onConnected={handleConnected} onConverted={handleConverted} photo={childhoodPhoto} />;
       case Screen.CHAT:
         if (!childhoodPhoto) {
             // Should not happen, but as a fallback
             setAppState({ screen: Screen.UPLOAD });
             return <UploadScreen onPhotoUpload={handlePhotoUpload} />;
         }
-        return <ChatScreen photo={childhoodPhoto} onEndCall={handleEndCall} />;
+        return <ChatScreen photo={convertedPhoto || childhoodPhoto} onEndCall={handleEndCall} />;
       default:
         return <UploadScreen onPhotoUpload={handlePhotoUpload} />;
     }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ View your app in AI Studio: https://ai.studio/apps/drive/1c_txGnhL39iUP2BXG-96nT
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create `.env.local` and set API keys:
+   - `VITE_OPENAI_API_KEY=...` (開発時にフロントからOpenAIを呼ぶ場合に使用)
+   - `VITE_GEMINI_API_KEY=...` (開発時にフロントからGeminiを呼ぶ場合に使用)
+   - 本番では `OPENAI_API_KEY` と `GEMINI_API_KEY` をデプロイ先の環境変数に設定してください
 3. Run the app:
    `npm run dev`
+
+## 画像の子ども化（Gemini）
+
+アップロードした画像は接続画面でGemini APIに送られ、子ども顔に変換されます。
+
+- 開発時（`import.meta.env.DEV`）
+  - `VITE_GEMINI_API_KEY` が設定されていれば、フロントからGeminiを直接呼び出します
+  - 未設定の場合はバックエンドの `/api/convert` を利用します
+- 本番
+  - 常に `/api/convert` を利用します（`GEMINI_API_KEY` 環境変数が必要）
+
+Geminiのモデル: `gemini-2.5-flash-image-preview`

--- a/api/convert.ts
+++ b/api/convert.ts
@@ -1,0 +1,102 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const { imageDataUrl } = req.body as { imageDataUrl?: string };
+    if (!imageDataUrl || typeof imageDataUrl !== "string") {
+      return res.status(400).json({ error: "imageDataUrl is required" });
+    }
+
+    const match = imageDataUrl.match(/^data:(.+);base64,(.*)$/);
+    if (!match) {
+      return res.status(400).json({ error: "Invalid data URL format" });
+    }
+
+    const mimeType = match[1];
+    const base64Data = match[2];
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return res.status(500).json({ error: "GEMINI_API_KEY is not configured" });
+    }
+
+    const prompt =
+      "Create a hyper-realistic portrait of the provided adult male, reimagined as himself at about 7–9 years old. The child must be instantly recognizable as the same person: preserve the unique facial structure, eye shape, nose, lips, and overall proportions, only adjusted naturally for a younger age. Key details: - Smooth, youthful skin with no wrinkles or facial hair. - Slightly rounder cheeks, smaller jawline, softer facial contours. - Eye size proportionally larger compared to the face, with a bright and innocent childlike gaze. - Hair should closely resemble the adult's current hairstyle, but shorter and appropriate for a school-aged boy, natural and neat. - Expression: calm, slightly smiling, gentle and curious, typical of a childhood portrait. - Outfit: realistic elementary school clothing, such as a plain white shirt, or a Japanese elementary school uniform (navy blazer, white shirt). - Environment: simple studio portrait with soft natural lighting and a neutral background. - Style: ultra photorealistic, extremely detailed, high-resolution photograph. Lighting and skin texture should look like a real professional portrait photograph, not a painting or illustration.";
+
+    const geminiResponse = await fetch(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image-preview:generateContent",
+      {
+        method: "POST",
+        headers: {
+          "x-goog-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          contents: [
+            {
+              parts: [
+                { text: prompt },
+                {
+                  inlineData: {
+                    mimeType,
+                    data: base64Data,
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      }
+    );
+
+    if (!geminiResponse.ok) {
+      const errorText = await geminiResponse.text();
+      return res.status(502).json({ error: "Gemini API request failed", detail: errorText });
+    }
+
+    const data = await geminiResponse.json();
+
+    // 生成結果から最初の画像パートを抽出
+    const candidates = data?.candidates || [];
+    let outputData: string | null = null;
+    let outputMime: string = "image/png";
+
+    for (const c of candidates) {
+      const parts = c?.content?.parts || [];
+      for (const p of parts) {
+        if (p?.inlineData?.data) {
+          outputData = p.inlineData.data;
+          outputMime = p.inlineData.mimeType || outputMime;
+          break;
+        }
+      }
+      if (outputData) break;
+    }
+
+    if (!outputData) {
+      return res.status(500).json({ error: "Gemini response did not include image data", raw: data });
+    }
+
+    const transformedDataUrl = `data:${outputMime};base64,${outputData}`;
+    return res.status(200).json({ transformedDataUrl });
+  } catch (error) {
+    return res.status(500).json({
+      error: "Image conversion failed",
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+

--- a/components/ConnectingScreen.tsx
+++ b/components/ConnectingScreen.tsx
@@ -1,18 +1,107 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ConnectingScreenProps {
   onConnected: () => void;
+  onConverted: (transformed: string) => void;
   photo: string | null;
 }
 
-const ConnectingScreen: React.FC<ConnectingScreenProps> = ({ onConnected, photo }) => {
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      onConnected();
-    }, 3500); // Simulate connection time
+const ConnectingScreen: React.FC<ConnectingScreenProps> = ({ onConnected, onConverted, photo }) => {
+  const [status, setStatus] = useState<'connecting' | 'converting' | 'done' | 'error'>('connecting');
 
-    return () => clearTimeout(timer);
-  }, [onConnected]);
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      if (!photo) return;
+      try {
+        setStatus('converting');
+
+        const isDevelopment = import.meta.env.DEV;
+
+        if (isDevelopment && import.meta.env.VITE_GEMINI_API_KEY) {
+          // Frontend direct call for dev only
+          const apiKey = import.meta.env.VITE_GEMINI_API_KEY as string;
+          const match = photo.match(/^data:(.+);base64,(.*)$/);
+          if (!match) throw new Error('Invalid image data URL');
+          const mimeType = match[1];
+          const base64Data = match[2];
+
+          const prompt = 'この写真を子供のころに変換してください。元の人間の特徴を維持しつつ、7歳くらいの幼い顔立ちにしてください。髪型や服装も年齢に合ったものにし、写実的な上半身のポートレートにしてください。';
+
+          const resp = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image-preview:generateContent', {
+            method: 'POST',
+            headers: {
+              'x-goog-api-key': apiKey,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              contents: [
+                {
+                  parts: [
+                    { text: prompt },
+                    { inlineData: { mimeType, data: base64Data } }
+                  ]
+                }
+              ]
+            })
+          });
+
+          if (!resp.ok) {
+            throw new Error(`Gemini request failed: ${resp.status}`);
+          }
+
+          const data = await resp.json();
+          let outData: string | null = null;
+          let outMime: string = 'image/png';
+          const candidates = data?.candidates || [];
+          for (const c of candidates) {
+            const parts = c?.content?.parts || [];
+            for (const p of parts) {
+              if (p?.inlineData?.data) {
+                outData = p.inlineData.data;
+                outMime = p.inlineData.mimeType || outMime;
+                break;
+              }
+            }
+            if (outData) break;
+          }
+          if (!outData) throw new Error('No image data in Gemini response');
+          const transformed = `data:${outMime};base64,${outData}`;
+          if (!cancelled) {
+            onConverted(transformed);
+            setStatus('done');
+            onConnected();
+          }
+        } else {
+          // Backend call (recommended for prod)
+          const resp = await fetch('/api/convert', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ imageDataUrl: photo })
+          });
+          if (!resp.ok) {
+            const text = await resp.text();
+            throw new Error(`Convert API failed: ${resp.status} ${text}`);
+          }
+          const json = await resp.json();
+          const transformed = json?.transformedDataUrl as string;
+          if (!transformed) throw new Error('Invalid convert API response');
+          if (!cancelled) {
+            onConverted(transformed);
+            setStatus('done');
+            onConnected();
+          }
+        }
+      } catch (e) {
+        console.error('Image conversion error', e);
+        if (!cancelled) setStatus('error');
+        // 失敗時でも一旦そのまま進める
+        if (!cancelled) onConnected();
+      }
+    }
+    run();
+    return () => { cancelled = true; };
+  }, [photo, onConverted, onConnected]);
 
   return (
     <div className="flex flex-col items-center justify-center h-full bg-black text-white p-8">
@@ -24,8 +113,8 @@ const ConnectingScreen: React.FC<ConnectingScreenProps> = ({ onConnected, photo 
           </div>
         </div>
       )}
-      <h2 className="text-2xl font-bold mb-2 animate-pulse">過去に接続中...</h2>
-      <p className="text-gray-400">時間リンクを確立しています。しばらくお待ちください。</p>
+      <h2 className="text-2xl font-bold mb-2 animate-pulse">{status === 'converting' ? '現在過去にタイムスリップしています...' : '過去に接続中...'}</h2>
+      <p className="text-gray-400">{status === 'converting' ? 'しばらくお待ちください。' : '時間リンクを確立しています。しばらくお待ちください。'}</p>
     </div>
   );
 };


### PR DESCRIPTION
- Gemini APIを使用してアップロード画像を7歳頃の子供顔に変換
- 開発環境ではVITE_GEMINI_API_KEYで直接API呼び出し
- 本番環境では/api/convertエンドポイント経由で変換
- ConnectingScreenで変換処理を実行し、変換後の画像をChatScreenで表示
- App.tsxで変換前後の画像を管理する状態を追加
- プロンプトを日本語に調整し、より自然な子供化を実現
- READMEに環境変数設定方法を追記
- 変換中のUIメッセージを「タイムスリップ」に変更してより親しみやすく