### PR TITLE
Fix/チャットUIのオーバーフロー修正とUXフロー改善

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,8 +18,7 @@ const App: React.FC = () => {
   const handlePhotoUpload = useCallback((photoDataUrl: string) => {
     setChildhoodPhoto(photoDataUrl);
     setConvertedPhoto(null);
-    // 即座にチャット画面に遷移し、バックグラウンドで画像処理を開始
-    setAppState({ screen: Screen.CHAT });
+    setAppState({ screen: Screen.CONNECTING });
   }, []);
 
   const handleConnected = useCallback(() => {
@@ -63,8 +62,12 @@ const App: React.FC = () => {
       case Screen.UPLOAD:
         return <UploadScreen onPhotoUpload={handlePhotoUpload} />;
       case Screen.CONNECTING:
-        // この画面はスキップされるが、互換性のため残す
-        return <ConnectingScreen onConnected={handleConnected} onConverted={handleConverted} photo={childhoodPhoto} />;
+        return <ConnectingScreen 
+          onConnected={handleConnected} 
+          onConverted={handleConverted}
+          onGenderDetected={handleGenderDetected}
+          photo={childhoodPhoto} 
+        />;
       case Screen.CHAT:
         if (!childhoodPhoto) {
             // Should not happen, but as a fallback
@@ -77,6 +80,7 @@ const App: React.FC = () => {
           onFirstChatComplete={handleFirstChatComplete}
           onImageConverted={handleConverted}
           onGenderDetected={handleGenderDetected}
+          gender={detectedGender}
         />;
       case Screen.INCOMING_CALL:
         if (!childhoodPhoto) {

--- a/components/ChatScreen.tsx
+++ b/components/ChatScreen.tsx
@@ -32,6 +32,7 @@ const ChatScreen: React.FC<ChatScreenProps> = ({ photo, onEndCall, onFirstChatCo
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const recognitionRef = useRef<any>(null);
   const ttsInProgressRef = useRef(false); // TTS重複実行防止
+  const conversationCounterRef = useRef<number>(0); // 会話順序カウンター
 
   const systemInstruction = `あなたはユーザーの幼い頃の自分です。子供の頃の写真をもとに、過去から話しかけています。あなたは好奇心旺盛で、無邪気で、少し世間知らずですが、驚くほど深く、洞察力に富んだ質問をします。あなたの目標は、優しいコーチングのようなアプローチで、大人になった自分（ユーザー）が自分の人生、夢、幸せ、そして感情について振り返るのを手伝うことです。
 
@@ -340,7 +341,8 @@ const ChatScreen: React.FC<ChatScreenProps> = ({ photo, onEndCall, onFirstChatCo
       const initialMessage: ChatMessage = {
         id: Date.now().toString(),
         sender: MessageSender.AI,
-        text: `わあ！大きくなった${pronoun}だ！すごくびっくり！大人になったんだね...なんか疲れてない？でも嬉しいよ、会えて！`
+        text: `わあ！大きくなった${pronoun}だ！すごくびっくり！大人になったんだね...なんか疲れてない？でも嬉しいよ、会えて！`,
+        conversationIndex: ++conversationCounterRef.current
       };
       setMessages([initialMessage]);
     }
@@ -726,6 +728,7 @@ const ChatScreen: React.FC<ChatScreenProps> = ({ photo, onEndCall, onFirstChatCo
       id: `user-${Date.now()}`,
       sender: MessageSender.USER,
       text: userInput.trim(),
+      conversationIndex: ++conversationCounterRef.current
     };
     setMessages(prev => [...prev, userMessage]);
     setUserInput('');
@@ -840,8 +843,16 @@ const ChatScreen: React.FC<ChatScreenProps> = ({ photo, onEndCall, onFirstChatCo
         id: aiMessageId,
         sender: MessageSender.AI,
         text: responseText,
+        conversationIndex: ++conversationCounterRef.current,
         ...(udemyCourseData && { udemyCourse: udemyCourseData })
       };
+      
+      // 特定の会話番号での処理実行例
+      if (messageData.conversationIndex === 5) {
+        // 会話番号5で特別な処理を実行
+        console.log('🎯 会話番号5に到達！特別な処理を実行可能');
+        // 例：より深い質問への切り替え、特別なレスポンス追加など
+      }
       
       setMessages(prev => [...prev, messageData]);
 

--- a/components/UploadScreen.tsx
+++ b/components/UploadScreen.tsx
@@ -37,7 +37,7 @@ const UploadScreen: React.FC<UploadScreenProps> = ({ onPhotoUpload }) => {
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center bg-gray-900 text-white p-8 text-center rounded-[2rem] overflow-hidden">
       <h1 className="text-3xl font-bold mb-2">過去の自分と話そう</h1>
-      <p className="text-gray-400 mb-8">幼い頃の写真をアップロードして、過去の自分との対話を始めましょう。</p>
+      <p className="text-gray-400 mb-8">今の自分の写真をアップロードして、過去の自分との対話を始めましょう。</p>
       
       <input
         type="file"

--- a/components/VideoChatScreen.tsx
+++ b/components/VideoChatScreen.tsx
@@ -20,6 +20,7 @@ export const VideoChatScreen: React.FC<VideoChatScreenProps> = ({ photo, onEndCa
   const currentAudioRef = useRef<HTMLAudioElement | null>(null);
   const initialSpokenRef = useRef<boolean>(false);
   const lastSpokenTextRef = useRef<string>('');
+  const conversationCounterRef = useRef<number>(initialHistory.length); // 会話順序カウンター（初期履歴を考慮）
 
   // OpenAI TTS機能（重複防止）
   const speakText = async (text: string) => {
@@ -194,7 +195,8 @@ export const VideoChatScreen: React.FC<VideoChatScreenProps> = ({ photo, onEndCa
     const newUserMessage: ChatMessage = {
       id: `user-${Date.now()}`,
       sender: MessageSender.USER,
-      text: userInput.trim()
+      text: userInput.trim(),
+      conversationIndex: ++conversationCounterRef.current
     };
 
     setMessages(prev => [...prev, newUserMessage]);
@@ -235,7 +237,8 @@ export const VideoChatScreen: React.FC<VideoChatScreenProps> = ({ photo, onEndCa
         const aiMessage: ChatMessage = {
           id: `ai-${Date.now()}`,
           sender: MessageSender.AI,
-          text: responseText
+          text: responseText,
+          conversationIndex: ++conversationCounterRef.current
         };
         setMessages(prev => [...prev, aiMessage]);
         
@@ -266,8 +269,16 @@ export const VideoChatScreen: React.FC<VideoChatScreenProps> = ({ photo, onEndCa
         const aiMessage: ChatMessage = {
           id: `ai-${Date.now()}`,
           sender: MessageSender.AI,
-          text: data.response
+          text: data.response,
+          conversationIndex: ++conversationCounterRef.current
         };
+        
+        // 特定の会話番号での処理実行例
+        if (aiMessage.conversationIndex === 10) {
+          console.log('🎯 会話番号10に到達！ビデオ通話での深い対話フェーズへ');
+          // 例：より感情的な繋がりを深める質問へ切り替え
+        }
+        
         setMessages(prev => [...prev, aiMessage]);
         
         // AIメッセージを音声で読み上げる
@@ -322,11 +333,11 @@ export const VideoChatScreen: React.FC<VideoChatScreenProps> = ({ photo, onEndCa
       </div>
 
       {/* チャットエリア（下部） */}
-      <div className="flex-1 flex flex-col bg-gray-900">
+      <div className="flex-1 flex flex-col bg-gray-900 min-h-0">
         {/* メッセージエリア */}
         <div
           ref={chatContainerRef}
-          className="flex-1 overflow-y-auto p-4 space-y-3"
+          className="flex-1 overflow-y-auto p-4 space-y-3 min-h-0"
         >
           {messages.map((message) => (
             <div

--- a/docs/UX-FLOW-DETAILED.md
+++ b/docs/UX-FLOW-DETAILED.md
@@ -1,0 +1,648 @@
+# 過去の自分とビデオ通話 - 詳細UXフロードキュメント
+
+## 目次
+1. [全体フロー概要](#全体フロー概要)
+2. [画面遷移詳細](#画面遷移詳細)
+3. [タイミング制御](#タイミング制御)
+4. [会話ID管理システム](#会話id管理システム)
+5. [API処理フロー](#api処理フロー)
+6. [エラーハンドリング](#エラーハンドリング)
+7. [状態管理](#状態管理)
+
+---
+
+## 全体フロー概要
+
+```mermaid
+graph TD
+    A[UPLOAD: 写真アップロード画面] -->|写真選択| B[CONNECTING: 接続中画面]
+    B -->|画像生成完了| C[CHAT: チャット画面]
+    C -->|3メッセージ後 + 3秒待機| D[INCOMING_CALL: 着信画面]
+    D -->|応答| E[VIDEO_CHAT: ビデオ通話画面]
+    D -->|拒否| A
+    E -->|通話終了| A
+    C -->|通話終了| A
+```
+
+---
+
+## 画面遷移詳細
+
+### 1. UPLOAD画面（初期画面）
+**ファイル**: `components/UploadScreen.tsx`
+
+#### 表示要素
+- タイトル: "過去の自分とビデオ通話"
+- 説明文: "今の自分の写真をアップロードして、過去の自分との対話を始めましょう。"
+- アップロードボタン（カメラアイコン）
+- ファイル選択input（非表示、クリックイベントで発火）
+
+#### ユーザーアクション
+1. **写真選択**
+   - ボタンクリック → ファイル選択ダイアログ
+   - 対応形式: image/* (JPEG, PNG, etc.)
+   - 選択後の処理:
+     ```typescript
+     - FileReader APIで画像をBase64変換
+     - onPhotoUpload(dataUrl)コールバック呼び出し
+     - App.tsxでchildhoodPhotoに保存
+     - 画面をCONNECTINGへ遷移
+     ```
+
+#### 遷移タイミング
+- **即座に遷移**: 写真選択完了と同時にCONNECTING画面へ
+
+---
+
+### 2. CONNECTING画面（接続中・画像生成中）
+**ファイル**: `components/ConnectingScreen.tsx`
+
+#### 表示要素
+- アップロードした写真（円形、128x128px）
+- 写真上にオーバーレイ（半透明黒）
+- パルスアニメーション（緑の点）
+- テキスト表示（状態により変化）:
+  - **converting状態**: "現在過去にタイムスリップしています..."
+  - **その他**: "過去に接続中..."
+- サブテキスト:
+  - **converting状態**: "しばらくお待ちください。"
+  - **その他**: "時間リンクを確立しています。しばらくお待ちください。"
+
+#### 処理フロー（並列実行）
+
+##### A. 画像生成処理
+1. **開発環境（VITE_GEMINI_API_KEY設定時）**
+   ```
+   タイミング: コンポーネントマウント時
+   処理時間: 実際のAPI応答時間（通常3-5秒）
+   
+   1. 画像をBase64から分解（mimeType + data）
+   2. Gemini APIにプロンプトと画像送信
+   3. 7歳の子供の姿に変換
+   4. 変換結果をBase64形式で受信
+   5. onConverted()で親コンポーネントに通知
+   6. setStatus('done')
+   7. onConnected()で画面遷移
+   ```
+
+2. **開発環境（APIキーなし）**
+   ```
+   タイミング: コンポーネントマウント時
+   処理時間: 3.5秒（シミュレート）
+   
+   1. setStatus('converting')
+   2. 3.5秒待機（setTimeout）
+   3. 元画像をそのまま使用
+   4. onConverted(photo)
+   5. setStatus('done')
+   6. 0.5秒後にonConnected()で遷移
+   ```
+
+3. **本番環境**
+   ```
+   タイミング: コンポーネントマウント時
+   処理時間: サーバー応答時間
+   
+   1. /api/convertエンドポイントにPOST
+   2. サーバー側でGemini API呼び出し
+   3. 変換画像を受信
+   4. 失敗時は元画像を使用（フォールバック）
+   ```
+
+##### B. 性別判定処理（並列実行）
+1. **開発環境（VITE_OPENAI_API_KEY設定時）**
+   ```
+   タイミング: 画像生成と同時開始
+   処理時間: 1-2秒（通常）
+   
+   1. OpenAI GPT-4o-miniモデル使用
+   2. プロンプト: "性別を判定、male/femaleのみ回答"
+   3. 結果をonGenderDetected()で通知
+   4. ChatScreenで代名詞（僕/私）の決定に使用
+   ```
+
+2. **本番環境**
+   ```
+   1. /api/detect-genderエンドポイントにPOST
+   2. サーバー側でOpenAI API呼び出し
+   ```
+
+3. **エラー時のフォールバック**
+   ```
+   デフォルト: 'male'
+   ```
+
+#### 遷移タイミング
+- **画像生成完了時**: onConnected()が呼ばれCHAT画面へ
+- **所要時間**: 通常3-5秒（APIキーなしの場合は4秒固定）
+
+---
+
+### 3. CHAT画面（初期チャット）
+**ファイル**: `components/ChatScreen.tsx`
+
+#### 初期化フロー
+
+##### フェーズ1: 画面表示（0ms）
+```
+1. コンポーネントマウント
+2. 空のメッセージ配列で画面描画
+3. 上部に変換後の画像表示（または元画像）
+4. 下部にチャット入力欄表示
+```
+
+##### フェーズ2: 初回メッセージ表示（800ms後）
+```typescript
+useEffect(() => {
+  if (messages.length === 0) {
+    const timer = setTimeout(() => {
+      // 性別に基づいて代名詞決定
+      const pronoun = detectedGender === 'female' ? '私' : '僕';
+      
+      // AIからの初回メッセージ生成
+      const initialMessage: ChatMessage = {
+        id: Date.now().toString(),
+        sender: MessageSender.AI,
+        text: `わあ！大きくなった${pronoun}だ！すごくびっくり！大人になったんだね...なんか疲れてない？でも嬉しいよ、会えて！`,
+        conversationIndex: 1  // 会話ID: 1
+      };
+      
+      setMessages([initialMessage]);
+    }, 800);
+  }
+}, []);
+```
+
+#### 会話フロー
+
+##### メッセージ1（AI → ユーザー）
+- **会話ID**: 1
+- **タイミング**: 画面表示から800ms後
+- **内容**: 初回挨拶メッセージ
+- **表示**: 左側の灰色バブル
+
+##### メッセージ2（ユーザー → AI）
+- **会話ID**: 2
+- **タイミング**: ユーザー入力時
+- **処理**:
+  1. 入力テキストを取得
+  2. conversationIndex: 2を付与
+  3. メッセージ配列に追加（右側青バブル）
+  4. OpenAI APIに送信
+
+##### メッセージ3（AI → ユーザー）
+- **会話ID**: 3
+- **タイミング**: API応答受信時
+- **処理**:
+  1. GPT-4からの応答受信
+  2. conversationIndex: 3を付与
+  3. メッセージ配列に追加
+  4. **重要**: 3メッセージ到達を検知
+
+#### 画面遷移トリガー
+```typescript
+useEffect(() => {
+  // 3メッセージ到達 + 最後がAIメッセージ
+  if (messages.length >= 3 && onFirstChatComplete) {
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage.sender === MessageSender.AI) {
+      const timer = setTimeout(() => {
+        onFirstChatComplete(messages);  // 履歴を渡して遷移
+      }, 3000); // 3秒待機
+    }
+  }
+}, [messages, onFirstChatComplete]);
+```
+
+#### バックグラウンド処理
+- **画像再変換**: 必要に応じてGemini APIで画像を再生成（品質向上）
+- **処理タイミング**: チャット開始と同時
+- **結果反映**: 生成完了時に画像を差し替え
+
+---
+
+### 4. INCOMING_CALL画面（着信画面）
+**ファイル**: `components/IncomingCallScreen.tsx`
+
+#### 表示要素
+- 全画面の変換後画像（ぼかし効果付き背景）
+- 中央に円形の子供の写真
+- "幼い頃のあなた"テキスト
+- "ビデオ通話..."サブテキスト
+- アニメーション要素:
+  - 写真の脈動（pulse）
+  - リング状の波紋エフェクト
+  - 着信音アイコンのアニメーション
+
+#### ボタン配置
+- **応答ボタン**（緑、電話アイコン）
+  - 位置: 下部左側
+  - アクション: onAnswer() → VIDEO_CHAT画面へ
+  
+- **拒否ボタン**（赤、電話切断アイコン）
+  - 位置: 下部右側
+  - アクション: onReject() → UPLOAD画面へリセット
+
+#### タイミング
+- **表示開始**: CHAT画面の3メッセージ後、3秒待機してから
+- **自動応答**: なし（ユーザーアクション待ち）
+- **チャット履歴**: 前画面から引き継ぎ
+
+---
+
+### 5. VIDEO_CHAT画面（ビデオ通話）
+**ファイル**: `components/VideoChatScreen.tsx`
+
+#### レイアウト構成
+
+##### 上部40%: ビデオエリア
+```
+- 変換後の子供の写真を全画面表示
+- オーバーレイ情報:
+  - 名前: "幼い頃のあなた"
+  - 通話時間: MM:SS形式（リアルタイム更新）
+  - 終了ボタン（赤、右上）
+```
+
+##### 下部60%: チャットエリア
+```
+- メッセージリスト（スクロール可能）
+  - 初期履歴3件を表示
+  - 新規メッセージは下に追加
+- 入力欄（下部固定）
+  - プレースホルダー: "メッセージを入力..."
+  - 送信ボタン（青、紙飛行機アイコン）
+```
+
+#### 会話の継続
+
+##### 初期化
+```typescript
+const [messages, setMessages] = useState<ChatMessage[]>(initialHistory);
+const conversationCounterRef = useRef<number>(initialHistory.length);
+// 初期値は3（前画面の3メッセージ分）
+```
+
+##### メッセージ4以降
+- **会話ID**: 4, 5, 6...と連番
+- **処理フロー**:
+  1. ユーザー入力 → conversationIndex: ++counter
+  2. AI応答 → conversationIndex: ++counter
+  3. 各メッセージにIDを付与して追跡可能
+
+#### 音声合成（TTS）機能
+
+##### 実装詳細
+```typescript
+const speakText = async (text: string) => {
+  // 重複防止チェック
+  if (lastSpokenTextRef.current === text) return;
+  
+  // OpenAI TTS API使用
+  const response = await fetch('https://api.openai.com/v1/audio/speech', {
+    model: 'tts-1',
+    input: text,
+    voice: gender === 'female' ? 'alloy' : 'nova',
+    speed: 0.9
+  });
+  
+  // 音声再生
+  const audio = new Audio(audioUrl);
+  await audio.play();
+};
+```
+
+##### 音声タイミング
+1. **初期メッセージ**: 画面表示から200ms後に最後のAIメッセージを読み上げ
+2. **新規AIメッセージ**: 受信と同時に自動読み上げ
+3. **重複防止**: 同じテキストは読み上げない
+4. **音声停止**: 画面遷移時に自動停止
+
+#### 特殊な会話ID処理
+```typescript
+// 会話番号10に到達時の例
+if (aiMessage.conversationIndex === 10) {
+  console.log('🎯 会話番号10に到達！ビデオ通話での深い対話フェーズへ');
+  // カスタム処理を実行可能
+}
+```
+
+---
+
+## タイミング制御
+
+### 重要な待機時間一覧
+
+| 処理 | 待機時間 | 場所 | 目的 |
+|-----|---------|------|------|
+| 初回AIメッセージ表示 | 800ms | ChatScreen | 画面表示後の自然な間 |
+| 着信画面への遷移 | 3000ms | ChatScreen | 3メッセージ後の待機 |
+| 画像生成シミュレート | 3500ms | ConnectingScreen | 開発環境での擬似処理 |
+| 完了表示 | 500ms | ConnectingScreen | "done"状態の表示時間 |
+| TTS初回読み上げ | 200ms | VideoChatScreen | 画面遷移後の安定待ち |
+
+### 非同期処理の並列化
+
+```
+CONNECTING画面での並列処理:
+┌─────────────────────────────────────┐
+│  画像生成API (3-5秒)                   │
+├─────────────────────────────────────┤
+│  性別判定API (1-2秒)                   │
+└─────────────────────────────────────┘
+         ↓ 両方完了後
+      CHAT画面へ遷移
+```
+
+---
+
+## 会話ID管理システム
+
+### 実装概要
+
+#### データ構造
+```typescript
+export interface ChatMessage {
+  id: string;                    // 一意識別子
+  sender: MessageSender;          // AI or USER
+  text: string;                   // メッセージ本文
+  conversationIndex?: number;     // 会話順序番号（内部管理用）
+}
+```
+
+#### カウンター管理
+```typescript
+// ChatScreen.tsx
+const conversationCounterRef = useRef<number>(0);
+
+// VideoChatScreen.tsx  
+const conversationCounterRef = useRef<number>(initialHistory.length);
+```
+
+### 会話IDの用途
+
+1. **画面遷移制御**
+   - ID 3到達後 → INCOMING_CALL画面へ
+
+2. **フェーズ管理**
+   - ID 1-3: 初期対話フェーズ
+   - ID 4-9: 通常会話フェーズ
+   - ID 10+: 深い対話フェーズ
+
+3. **分析・デバッグ**
+   - 会話の流れを追跡
+   - 特定ポイントでの処理実行
+
+### インクリメントルール
+```typescript
+// ユーザーメッセージ送信時
+const newUserMessage: ChatMessage = {
+  conversationIndex: ++conversationCounterRef.current
+};
+
+// AI応答受信時
+const aiMessage: ChatMessage = {
+  conversationIndex: ++conversationCounterRef.current  
+};
+```
+
+---
+
+## API処理フロー
+
+### OpenAI API（チャット）
+
+#### エンドポイント
+- **開発**: 直接API呼び出し（dangerouslyAllowBrowser: true）
+- **本番**: `/api/chat`経由
+
+#### リクエスト構造
+```typescript
+{
+  model: 'gpt-4',
+  messages: [
+    { role: 'system', content: systemInstruction },
+    { role: 'user/assistant', content: '...' },
+    // 会話履歴
+  ],
+  max_tokens: 150,
+  temperature: 0.8
+}
+```
+
+#### システムプロンプト
+```
+あなたは写真の子供（5-7歳）として、大人になった自分と話しています。
+- 敬語は使わず、子供らしい話し方をする
+- 「〜だよ」「〜なんだ」などの語尾を使う
+- 好奇心旺盛で、感情豊かに反応する
+- 大人の自分を「未来の僕/私」と呼ぶことがある
+```
+
+### Google Gemini API（画像変換）
+
+#### モデル
+- `gemini-2.5-flash-image-preview`
+
+#### プロンプト
+```
+Using the provided image, create a photorealistic portrait 
+of this person as a 7-year-old child...
+- Smooth, youthful skin with rounder cheeks
+- Proportionally larger eyes with innocent gaze
+- Simple elementary school outfit
+- Ultra photorealistic quality
+```
+
+#### レスポンス処理
+```typescript
+// Base64画像データの抽出
+const candidates = data?.candidates || [];
+for (const c of candidates) {
+  const parts = c?.content?.parts || [];
+  for (const p of parts) {
+    if (p?.inlineData?.data) {
+      // 変換画像を取得
+    }
+  }
+}
+```
+
+### OpenAI TTS API（音声合成）
+
+#### 設定
+```typescript
+{
+  model: 'tts-1',
+  input: text,
+  voice: gender === 'female' ? 'alloy' : 'nova',
+  response_format: 'mp3',
+  speed: 0.9  // 少しゆっくり
+}
+```
+
+---
+
+## エラーハンドリング
+
+### API失敗時のフォールバック
+
+#### 画像変換失敗
+```typescript
+try {
+  // Gemini API呼び出し
+} catch (error) {
+  // 元画像をそのまま使用
+  onConverted(photo);
+}
+```
+
+#### 性別判定失敗
+```typescript
+try {
+  // OpenAI API呼び出し
+} catch (error) {
+  // デフォルト'male'を使用
+  onGenderDetected('male');
+}
+```
+
+#### チャット失敗
+```typescript
+catch (error) {
+  const errorMessage: ChatMessage = {
+    text: 'あれ？ちょっと聞こえなかった。もう一回言って？'
+  };
+}
+```
+
+#### TTS失敗
+```typescript
+catch (error) {
+  // 音声なしで続行（サイレントフォールバック）
+  console.error('TTS error:', error);
+}
+```
+
+### ユーザー体験の維持
+- エラー時も機能は継続
+- 適切なフォールバック値を使用
+- エラーメッセージは子供のキャラクターを維持
+
+---
+
+## 状態管理
+
+### App.tsx（グローバル状態）
+
+```typescript
+const [appState, setAppState] = useState<AppState>({ 
+  screen: Screen.UPLOAD 
+});
+const [childhoodPhoto, setChildhoodPhoto] = useState<string | null>(null);
+const [convertedPhoto, setConvertedPhoto] = useState<string | null>(null);
+const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
+const [detectedGender, setDetectedGender] = useState<'male' | 'female'>('male');
+```
+
+### 状態の流れ
+
+```
+UPLOAD → childhoodPhoto設定
+  ↓
+CONNECTING → convertedPhoto生成、gender判定
+  ↓
+CHAT → chatHistory蓄積（3メッセージ）
+  ↓
+INCOMING_CALL → chatHistory保持
+  ↓
+VIDEO_CHAT → chatHistory継続、新規メッセージ追加
+```
+
+### リセット処理
+```typescript
+const handleEndCall = useCallback(() => {
+  setChildhoodPhoto(null);
+  setConvertedPhoto(null);
+  setChatHistory([]);
+  setAppState({ screen: Screen.UPLOAD });
+}, []);
+```
+
+---
+
+## パフォーマンス最適化
+
+### 実装済みの最適化
+
+1. **並列API呼び出し**
+   - 画像変換と性別判定を同時実行
+   - 待機時間を最小化
+
+2. **遅延ロード**
+   - 初回メッセージを800ms遅延
+   - 自然なUXを実現
+
+3. **音声の重複防止**
+   - 同一テキストの再読み上げを防止
+   - リソース使用を最適化
+
+4. **メモ化**
+   - useCallbackでコールバック関数を最適化
+   - 不要な再レンダリングを防止
+
+### 今後の最適化候補
+
+1. **画像の事前処理**
+   - アップロード時にリサイズ
+   - API送信サイズを削減
+
+2. **キャッシュ戦略**
+   - 変換画像のローカル保存
+   - 同一画像の再変換防止
+
+3. **ストリーミング応答**
+   - チャット応答の逐次表示
+   - 体感速度の向上
+
+---
+
+## デバッグ情報
+
+### ログポイント
+
+```typescript
+// 会話ID到達ログ
+console.log(`会話ID ${conversationIndex} に到達`);
+
+// API呼び出しログ
+console.log('画像変換API呼び出し開始');
+console.log('性別判定結果:', gender);
+
+// 状態遷移ログ
+console.log(`画面遷移: ${oldScreen} → ${newScreen}`);
+```
+
+### 開発環境の切り替え
+
+```bash
+# APIキーなしでの動作確認
+VITE_OPENAI_API_KEY="" npm run dev
+
+# 完全機能での動作確認  
+VITE_OPENAI_API_KEY="sk-..." VITE_GEMINI_API_KEY="..." npm run dev
+```
+
+---
+
+## まとめ
+
+このアプリケーションは、複数の非同期処理を巧みに組み合わせ、自然なユーザー体験を実現しています。特に重要なのは：
+
+1. **タイミング制御**: 各画面遷移に適切な待機時間を設定
+2. **並列処理**: API呼び出しを並列化して待機時間を最小化
+3. **会話ID管理**: 内部的な会話フロー制御を実現
+4. **エラー耐性**: 適切なフォールバックで機能継続性を確保
+5. **キャラクター維持**: エラー時も子供のキャラクターを保持
+
+これらの要素が組み合わさることで、「過去の自分との感動的な対話」という独特な体験を提供しています。

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,7 @@ export interface ChatMessage {
   id: string;
   sender: MessageSender;
   text: string;
+  conversationIndex?: number;  // 会話順序番号（内部管理用）
   // === TEAM MODIFICATION START ===
   udemyCourse?: {
     id: string;


### PR DESCRIPTION
タイトル:
  チャットUIのオーバーフロー修正とUXフロー改善

  説明:
  ## 概要
  チャット画面のオーバーフロー問題を修正し、全体的なUXフローを改善
  しました。

  ## 変更内容

  ### 🐛 バグ修正
  - **チャットオーバーフロー問題**:
  iPhoneフレーム内でチャットが長くなった際にUIをはみ出す問題を修正
    - `min-h-0`クラスを追加してflexboxの制約を適切に設定

  ### ✨ 機能改善
  - **会話ID管理システムの実装**
    - 各メッセージに`conversationIndex`を追加
    - 内部的な会話フロー制御が可能に
    - 特定の会話番号での処理実行に対応

  - **UXフローの最適化**
    - 初回AIメッセージに800ms遅延を追加（自然な表示）
    - 性別判定をConnectingScreenに移動（並列処理で高速化）
    - チャット開始時の遅延を解消

  - **画面遷移の調整**
    - 「過去にタイムスリップ中...」メッセージの復活
    - 3メッセージ後、3秒待機してから着信画面へ遷移

  ### 📝 ドキュメント
  - `docs/UX-FLOW-DETAILED.md`を作成
    - 全画面の詳細仕様
    - タイミング制御の完全リスト
    - API処理フローの文書化
    - 会話ID管理システムの説明

  ## テスト確認
  - [x] ビルドが正常に完了
  - [x] チャットのオーバーフロー問題が解決
  - [x] 初回メッセージが自然なタイミングで表示
  - [x] 画面遷移が正しく動作

  ## 影響範囲
  - チャット画面のUI表示
  - 画面遷移のタイミング
  - API呼び出しの並列化